### PR TITLE
Removed the bintray repository as it no longer exists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ buildNumber.properties
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
+.vscode/settings.json

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.vaadin.maxime</groupId>
     <artifactId>markdown-area</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <name>Markdown Area</name>
     <description>A simple TextArea to preview the markdown syntax</description>
 
@@ -52,12 +52,6 @@
         <repository>
             <id>Vaadin prereleases</id>
             <url>http://maven.vaadin.com/vaadin-prereleases</url>
-        </repository>
-        <!-- The bintray repository contain webjars immediately after generation. If the webjar is available
-             in Maven central, you do not need this repository -->
-        <repository>
-            <id>webjars</id>
-            <url>https://dl.bintray.com/webjars/maven</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
The existance of the bintray repository was causing dozens of warning during the maven build process and given that the bintray repo no longer exists it serves no purpose.